### PR TITLE
connection modal and disconnection modal

### DIFF
--- a/frontend/app/components/ConnectButton/index.tsx
+++ b/frontend/app/components/ConnectButton/index.tsx
@@ -1,31 +1,48 @@
+import { useState } from "react";
 import { useJigitContext } from "@/app/context";
 import { Button } from "../button";
 
 function ConnectButton() {
   const { connection, connectWallet, disconnectWallet } = useJigitContext();
+  const [isModalOpen, setModalOpen] = useState(false);
+
+  const handleAction = () => {
+    if (connection) {
+      disconnectWallet();
+    } else {
+      connectWallet();
+    }
+    setModalOpen(false);
+  };
 
   return (
     <section>
-      {connection ? (
-        // <button
-        //   type="button"
-        //   className="border rounded-lg shadow-md border-black bg-white text-purple-950 py-2 px-4 mb-2"
-        //   onClick={disconnectWallet}
-        // >
-        //   Disconnect
-        // </button>
-        <Button text="Disconnect" onClick={disconnectWallet} />
-      ) : (
-        // <button
-        //   type="button"
-        //   className="border rounded-lg shadow-md border-black bg-white text-purple-950 py-2 px-4 mb-2"
-        //   onClick={connectWallet}
-        // >
-        //   Connect Wallet
-        // </button>
-        <Button text="Connect Wallet" onClick={connectWallet} />
+      <Button 
+        text={connection ? "Disconnect" : "Connect Wallet"} 
+        onClick={() => setModalOpen(true)} 
+      />
+
+      {/* Modal */}
+      {isModalOpen && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+          <div className="bg-white p-6 rounded-lg shadow-lg text-center">
+            <h2 className="text-lg font-semibold mb-4">
+              {connection ? "Disconnect Wallet" : "Connect Wallet"}
+            </h2>
+            <p className="mb-4">
+              {connection
+                ? "Are you sure you want to disconnect your wallet?"
+                : "Would you like to connect your wallet?"}
+            </p>
+            <div className="flex justify-center gap-4">
+              <Button text="Cancel" onClick={() => setModalOpen(false)} />
+              <Button text={connection ? "Disconnect" : "Connect"} onClick={handleAction} />
+            </div>
+          </div>
+        </div>
       )}
     </section>
   );
 }
+
 export default ConnectButton;


### PR DESCRIPTION
This PR introduces a modal confirmation UI for wallet connection actions. Instead of immediately triggering wallet connect or disconnect actions, users now see a modal prompting them to confirm their choice. This enhancement improves user experience by preventing accidental disconnections or connections.

Changes Made:

Modal Integration:

Added a modal overlay that displays when the connect/disconnect button is clicked.

The modal shows context-specific messaging ("Connect Wallet" vs. "Disconnect Wallet") based on the connection state.

Confirmation Workflow:

On modal confirmation, the component calls connectWallet or disconnectWallet accordingly.

A cancel button is provided to close the modal without taking any action.

UI Updates:

Utilized existing Button component for consistency.

Applied Tailwind CSS classes for styling the modal and buttons.

How to Test:

Click the "Connect Wallet" button when not connected:

The modal should display a prompt asking if you'd like to connect.

Confirming should trigger the connectWallet function.

Once connected, click the "Disconnect" button:

The modal should display a prompt asking if you'd like to disconnect.

Confirming should trigger the disconnectWallet function.

Use the cancel button in the modal to ensure it closes without taking action.

Additional Notes:

This implementation leverages the useJigitContext for managing wallet connection state.

The modal is integrated directly within the ConnectButton component to keep the flow simple.

Please review the changes and provide feedback. Thanks!

